### PR TITLE
Fix madr 2.1.0 tests

### DIFF
--- a/tests/create-first-record-madr.expected
+++ b/tests/create-first-record-madr.expected
@@ -32,12 +32,12 @@ Technical Story: [description | ticket/issue URL] <!-- optional -->
 
 Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
 
-### Positive Consequences: <!-- optional -->
+### Positive Consequences <!-- optional -->
 
 * [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
 * …
 
-### Negative consequences: <!-- optional -->
+### Negative consequences <!-- optional -->
 
 * [e.g., compromising quality attribute, follow-up decisions required, …]
 * …


### PR DESCRIPTION
The `create-first-record-madr` was broken because of the latest change on madr 2.1.0 template